### PR TITLE
HTML tag cleanup and logo centering

### DIFF
--- a/WebsiteBuilder/src/css/styles.css
+++ b/WebsiteBuilder/src/css/styles.css
@@ -137,6 +137,7 @@ a {
 .logo {
   height: 15em;
   width: 90%;
+  margin: auto;
 
   background-image: url("../images/logotype\ textwhite.png");
   background-size: contain;

--- a/WebsiteBuilder/src/pages/events.html
+++ b/WebsiteBuilder/src/pages/events.html
@@ -262,32 +262,32 @@
         <div class="bread">
           <div class="textblock">After a long night of dancing and partying, it’s nice to relax and recuperate. At The
             Well warm pools, jacuzzis, steam bath and other wellness attractions awaits your sore muscles and aching
-            heads.</a>
-            <div class="textblock">This is not an 'official' event, and tickets cannot be bought through Pawske Party.
-              We're happy to coordinate a group of those who want to go to the well together and enjoy a Spa day there.
-              Please be aware that you have to buy your ticket for The Well separately.</a>
-              <div class="textblock">The Well is the biggest spa center in the Nordic region and offers a wide array of
-                things to do, including various wellness rituals that are included in the ticket. On their website you
-                can also add up-charges like a massage or various skin treatments. We recommend you check out their <a
-                  href="https://thewell.no/en/">website</a> for all they have to offer.</a>
-                <div class="textblock">At The Well you are free to choose between being naked and wearing swimming
-                  clothes. Saunas can only be used naked. You are only allowed to wear The Well’s own brand that can be
-                  bought in the reception upon arrival.</a>
-                  <div class="textblock">The Well is located a bit outside of Oslo and is accessed by car or bus. There
-                    will not be an organized travel out to the center, but it is easy to find. The Well is located at
-                    Kongeveien 65, 1412 Sofiemyr and has its own parking lot. From Jernbanetorget in Oslo you can take
-                    bus 81 towards Myrvoll Stasjon to Granholtet. Find your best route on <a
-                      href="https://entur.no/">EnTur</a> or through Google.</a>
-                    <div class="textblock">We’ll gather by the front entrance sunday 20.4. at 12:00. Keep in mind that
-                      you can essentially come and go as you please, as this is just a group coordination offer.</a>
-                      <div class="textblock">For more details and the prices check <a href="https://thewell.no/en/">The
-                          Well's Website</a>.</div>
-                    </div>
-                  </div>
+            heads.</div>
+          <div class="textblock">This is not an 'official' event, and tickets cannot be bought through Pawske Party.
+            We're happy to coordinate a group of those who want to go to the well together and enjoy a Spa day there.
+            Please be aware that you have to buy your ticket for The Well separately.</div>
+          <div class="textblock">The Well is the biggest spa center in the Nordic region and offers a wide array of
+            things to do, including various wellness rituals that are included in the ticket. On their website you
+            can also add up-charges like a massage or various skin treatments. We recommend you check out their <a
+              href="https://thewell.no/en/">website</a> for all they have to offer.</div>
+          <div class="textblock">At The Well you are free to choose between being naked and wearing swimming
+            clothes. Saunas can only be used naked. You are only allowed to wear The Well’s own brand that can be
+            bought in the reception upon arrival.</div>
+          <div class="textblock">The Well is located a bit outside of Oslo and is accessed by car or bus. There
+            will not be an organized travel out to the center, but it is easy to find. The Well is located at
+            Kongeveien 65, 1412 Sofiemyr and has its own parking lot. From Jernbanetorget in Oslo you can take
+            bus 81 towards Myrvoll Stasjon to Granholtet. Find your best route on <a href="https://entur.no/">EnTur</a>
+            or through Google.</div>
+          <div class="textblock">We’ll gather by the front entrance sunday 20.4. at 12:00. Keep in mind that
+            you can essentially come and go as you please, as this is just a group coordination offer.</div>
+          <div class="textblock">For more details and the prices check <a href="https://thewell.no/en/">The
+              Well's Website</a>.</div>
+        </div>
+      </div>
 
-                </div>
-                {{-partial "footer.html"-}}
-              </div>
+    </div>
+    {{-partial "footer.html"-}}
+  </div>
 </body>
 
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -137,6 +137,7 @@ a {
 .logo {
   height: 15em;
   width: 90%;
+  margin: auto;
 
   background-image: url("../images/logotype\ textwhite.png");
   background-size: contain;

--- a/events.html
+++ b/events.html
@@ -314,31 +314,31 @@
         <div class="bread">
           <div class="textblock">After a long night of dancing and partying, it’s nice to relax and recuperate. At The
             Well warm pools, jacuzzis, steam bath and other wellness attractions awaits your sore muscles and aching
-            heads.</a>
-            <div class="textblock">This is not an 'official' event, and tickets cannot be bought through Pawske Party.
-              We're happy to coordinate a group of those who want to go to the well together and enjoy a Spa day there.
-              Please be aware that you have to buy your ticket for The Well separately.</a>
-              <div class="textblock">The Well is the biggest spa center in the Nordic region and offers a wide array of
-                things to do, including various wellness rituals that are included in the ticket. On their website you
-                can also add up-charges like a massage or various skin treatments. We recommend you check out their <a
-                  href="https://thewell.no/en/">website</a> for all they have to offer.</a>
-                <div class="textblock">At The Well you are free to choose between being naked and wearing swimming
-                  clothes. Saunas can only be used naked. You are only allowed to wear The Well’s own brand that can be
-                  bought in the reception upon arrival.</a>
-                  <div class="textblock">The Well is located a bit outside of Oslo and is accessed by car or bus. There
-                    will not be an organized travel out to the center, but it is easy to find. The Well is located at
-                    Kongeveien 65, 1412 Sofiemyr and has its own parking lot. From Jernbanetorget in Oslo you can take
-                    bus 81 towards Myrvoll Stasjon to Granholtet. Find your best route on <a
-                      href="https://entur.no/">EnTur</a> or through Google.</a>
-                    <div class="textblock">We’ll gather by the front entrance sunday 20.4. at 12:00. Keep in mind that
-                      you can essentially come and go as you please, as this is just a group coordination offer.</a>
-                      <div class="textblock">For more details and the prices check <a href="https://thewell.no/en/">The
-                          Well's Website</a>.</div>
-                    </div>
-                  </div>
+            heads.</div>
+          <div class="textblock">This is not an 'official' event, and tickets cannot be bought through Pawske Party.
+            We're happy to coordinate a group of those who want to go to the well together and enjoy a Spa day there.
+            Please be aware that you have to buy your ticket for The Well separately.</div>
+          <div class="textblock">The Well is the biggest spa center in the Nordic region and offers a wide array of
+            things to do, including various wellness rituals that are included in the ticket. On their website you
+            can also add up-charges like a massage or various skin treatments. We recommend you check out their <a
+              href="https://thewell.no/en/">website</a> for all they have to offer.</div>
+          <div class="textblock">At The Well you are free to choose between being naked and wearing swimming
+            clothes. Saunas can only be used naked. You are only allowed to wear The Well’s own brand that can be
+            bought in the reception upon arrival.</div>
+          <div class="textblock">The Well is located a bit outside of Oslo and is accessed by car or bus. There
+            will not be an organized travel out to the center, but it is easy to find. The Well is located at
+            Kongeveien 65, 1412 Sofiemyr and has its own parking lot. From Jernbanetorget in Oslo you can take
+            bus 81 towards Myrvoll Stasjon to Granholtet. Find your best route on <a href="https://entur.no/">EnTur</a>
+            or through Google.</div>
+          <div class="textblock">We’ll gather by the front entrance sunday 20.4. at 12:00. Keep in mind that
+            you can essentially come and go as you please, as this is just a group coordination offer.</div>
+          <div class="textblock">For more details and the prices check <a href="https://thewell.no/en/">The
+              Well's Website</a>.</div>
+        </div>
+      </div>
 
-                </div>
-                <footer>
+    </div>
+    <footer>
     <div class="about">
         Pawske party © 2023-2025 <br>
         orgnr: 930 235 490
@@ -357,7 +357,7 @@
         </div>
     </div>
 </footer>
-              </div>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
Several <div> elements were "closed" with </a> tags, replaced the incorrect tags with </div>

Main pawske logo was uncentered with the rest of the page.