### PR TITLE
MetaTags and overscroll color

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/WebsiteBuilder/src/css/styles.css
+++ b/WebsiteBuilder/src/css/styles.css
@@ -56,6 +56,11 @@ html {
 
   font-family: "louis_george_caferegularRegular";
   font-size: 1em;
+
+  /*Stop overscrolling from showing white background*/
+  background-color: #2e0140;
+  overscroll-behavior:contain ;
+
 }
 
 body {

--- a/WebsiteBuilder/src/partials/head.html
+++ b/WebsiteBuilder/src/partials/head.html
@@ -2,6 +2,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/applications.html
+++ b/applications.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/css/styles.css
+++ b/css/styles.css
@@ -56,6 +56,11 @@ html {
 
   font-family: "louis_george_caferegularRegular";
   font-size: 1em;
+
+  /*Stop overscrolling from showing white background*/
+  background-color: #2e0140;
+  overscroll-behavior:contain ;
+
 }
 
 body {

--- a/events.html
+++ b/events.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/faq.html
+++ b/faq.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/gallery.html
+++ b/gallery.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/team.html
+++ b/team.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/tickets.html
+++ b/tickets.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/tosncoc.html
+++ b/tosncoc.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">


### PR DESCRIPTION
Phone version of the page would show a white background if you scrolled "past the end of the page", added a fallback background color to make this less harsh and noticeable.

Also added the theme-color meta tag for browsers that use this, for example safari will theme the user interface (URL bar, navigation buttons) based on this tag.